### PR TITLE
Fix encoding problem in chan listings

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -340,7 +340,7 @@ class KodiMediaset(object):
                 for prog in chan['listings']:
                     if prog['startTime'] <= now <= prog['endTime']:
                         guid = chan['guid']
-                        chans[guid] = {'title': '{} - {}'.format(chan['title'],
+                        chans[guid] = {'title': '{} - {}'.format(kodiutils.py2_encode(chan['title']),
                                                                  kodiutils.py2_encode(
                                                                      prog["mediasetlisting$epgTitle"])),
                                        'infos': _gather_info(prog),


### PR DESCRIPTION
SInce yesterday the channel listing has been failing to load. I found this in my kodi log:

```
2021-03-23 14:32:14.478 T:1722876800   DEBUG: plugin.video.videomediaset: Trying to get the live programs
2021-03-23 14:32:15.002 T:1722876800   DEBUG: plugin.video.videomediaset: Opening url https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-listings?byListingTime=1616506332999~1616506334000
2021-03-23 14:32:16.216 T:1722876800   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnicodeEncodeError'>
                                            Error Contents: 'ascii' codec can't encode character u'\u2019' in position 45: ordinal not in range(128)
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/default.py", line 5, in <module>
                                                km.main()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 533, in main
                                                self.canali_live_root()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 343, in canali_live_root
                                                chans[guid] = {'title': '{} - {}'.format(chan['title'], prog["mediasetlisting$epgTitle"].encode('ascii', 'ignore')),
                                            UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 45: ordinal not in range(128)
                                            -->End of Python script error report<--
```

Attached patch fixed the issue. I guess the problem was caused by this totle in the channel listing json:

```
"title": "Diretta live Isola Party: guardiamo assieme l’Isola dei Famosi con Andrea Dianetti e Valeria Angione",
```

which looks like something that may have appeared recently.