### PR TITLE
Avoid possible `KeyError: 'mediasetstation$eventBased'` error.

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -349,7 +349,7 @@ class KodiMediaset(object):
         els = self.med.OttieniCanaliLive(sort='ShortTitle')
         for prog in els:
             if (prog['callSign'] in chans and 'tuningInstruction' in prog and
-                    prog['tuningInstruction'] and not prog['mediasetstation$eventBased']):
+                    prog['tuningInstruction'] and not prog.get('mediasetstation$eventBased', False)):
                 chn = chans[prog['callSign']]
                 if chn['arts'] == {}:
                     chn['arts'] = _gather_art(prog)

--- a/resources/main.py
+++ b/resources/main.py
@@ -291,7 +291,7 @@ class KodiMediaset(object):
             infos = _gather_info(prog)
             arts = _gather_art(prog)
             if 'tuningInstruction' in prog:
-                if prog['tuningInstruction'] and not prog['mediasetstation$eventBased']:
+                if prog['tuningInstruction'] and not prog.get('mediasetstation$eventBased', False):
                     kodiutils.addListItem(prog["title"],
                                           {'mode': 'guida_tv', 'id': prog['callSign'],
                                            'week': staticutils.get_timestamp_midnight()},


### PR DESCRIPTION
I just got this error while trying to load the live channel listing:

```
2021-03-31 14:12:00.837 T:1672287104   DEBUG: plugin.video.videomediaset: Opening url https://static3.mediasetplay.mediaset.it/apigw/nownext/B6.json
2021-03-31 14:12:01.044 T:1672287104   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: 'mediasetstation$eventBased'
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/default.py", line 5, in <module>
                                                km.main()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 533, in main
                                                self.canali_live_root()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 350, in canali_live_root
                                                prog['tuningInstruction'] and not prog['mediasetstation$eventBased']):
                                            KeyError: 'mediasetstation$eventBased'
                                            -->End of Python script error report<--
2021-03-31 14:12:01.044 T:1672287104   DEBUG: onExecutionDone(12, /storage/.kodi/addons/plugin.video.videomediaset/default.py)
```

This patch sidesteps it using .get() with a default.

This is happening on kodi 18.9.0, in LibreELEC 9.2.6