### PR TITLE
Fix character encoding problem.

### DIFF
--- a/resources/lib/mediaset.py
+++ b/resources/lib/mediaset.py
@@ -1,6 +1,6 @@
 import json
 import xml.etree.ElementTree as ET
-from phate89lib import rutils, staticutils  # pylint: disable=import-error
+from phate89lib import kodiutils, rutils, staticutils  # pylint: disable=import-error
 try:
     from urllib.parse import urlencode, quote
 except ImportError:
@@ -428,7 +428,7 @@ class Mediaset(rutils.RUtils):
                     '&assetTypes=HD,browser,widevine,geoIT|geoNo:HD,browser,geoIT|geoNo:HD,'
                     'geoIT|geoNo:SD,''browser,widevine,geoIT|geoNo:SD,browser,geoIT|geoNo:SD,'
                     'geoIT|geoNo')
-        text = self.getText(u)
+        text = kodiutils.py2_encode(self.getText(u))
         res = {'url': '', 'pid': '', 'type': '', 'security': False}
         root = ET.fromstring(text)
         for vid in root.findall('.//{http://www.w3.org/2005/SMIL21/Language}switch'):

--- a/resources/lib/mediaset.py
+++ b/resources/lib/mediaset.py
@@ -1,6 +1,6 @@
 import json
 import xml.etree.ElementTree as ET
-from phate89lib import kodiutils, rutils, staticutils  # pylint: disable=import-error
+from phate89lib import rutils, staticutils  # pylint: disable=import-error
 try:
     from urllib.parse import urlencode, quote
 except ImportError:
@@ -428,7 +428,7 @@ class Mediaset(rutils.RUtils):
                     '&assetTypes=HD,browser,widevine,geoIT|geoNo:HD,browser,geoIT|geoNo:HD,'
                     'geoIT|geoNo:SD,''browser,widevine,geoIT|geoNo:SD,browser,geoIT|geoNo:SD,'
                     'geoIT|geoNo')
-        text = kodiutils.py2_encode(self.getText(u))
+        text = self.getText(u).encode('utf-8')
         res = {'url': '', 'pid': '', 'type': '', 'security': False}
         root = ET.fromstring(text)
         for vid in root.findall('.//{http://www.w3.org/2005/SMIL21/Language}switch'):


### PR DESCRIPTION
Today I found a new encoding problem.

The offending upstream URL is: https://link.theplatform.eu/s/PR1GhC/media/FFoEMf_H9Naf?auto=true&balance=true&format=SMIL&formats=MPEG-DASH,MPEG4,M3U&tracking=true&assetTypes=HD,browser,widevine,geoIT%7CgeoNo:HD,browser,geoIT%7CgeoNo:HD,geoIT%7CgeoNo:SD,browser,widevine,geoIT%7CgeoNo:SD,browser,geoIT%7CgeoNo:SD,geoIT%7CgeoNo

this is the content:

```
<smil xmlns="http://www.w3.org/2005/SMIL21/Language">
<head>
</head>
<body>
<seq>
<switch>
	<video src="https://restart3.msf.cdn.mediaset.net/Content/dash_d0_clr_vos/StartOver/Channel(name=b6,startTime=16201575040000000,endTime=16201688990000000)/manifest.mpd?hdnts=st=1620162209~exp=1620176639~acl=/Content/dash_d0_clr_vos/StartOver/Channel(name=b6,startTime=16201575040000000,endTime=16201688990000000)*~hmac=f4d4e2aeac0a05603664ae06749c91de377a1ca3769e5385f332344fe711d9ec" system-bitrate="0"/>
	<ref src="https://restart3.msf.cdn.mediaset.net/Content/dash_d0_clr_vos/StartOver/Channel(name=b6,startTime=16201575040000000,endTime=16201688990000000)/manifest.mpd?hdnts=st=1620162209~exp=1620176639~acl=/Content/dash_d0_clr_vos/StartOver/Channel(name=b6,startTime=16201575040000000,endTime=16201688990000000)*~hmac=f4d4e2aeac0a05603664ae06749c91de377a1ca3769e5385f332344fe711d9ec" title="RESTART: Finché c&apos;è guerra c&apos;è speranza" guid="196585000007_VIDEO_RESTART" type="application/dash+xml" expression="nonstop">
		<param name="trackingData" value="aid=2702976343|b=0|bc=FINC-MSIT|ci=1|cid=736450629466|d=1620162239786|l=0|mediaPid=FFoEMf_H9Naf|pd=1618911101000|pgid=F000351701000101|pid=PeCBe8knFc4V|rid=736452165137|rnid=111258909"/>
	</ref>
</switch>
</seq>
</body>
</smil>
```


The title of the movie has lots of accented letters. I guess one of those is the offending one.

I simply wrap the extracted string in an encode call, that fixed the issue.