### PR TITLE
Prevent crash due to 403 error from upstream API

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -386,7 +386,9 @@ class KodiMediaset(object):
 
     def __ottieni_vid_restart(self, guid):
         res = self.med.OttieniLiveStream(guid)
-        if ('currentListing' in res[0] and
+        if (res is not None and
+                res[0] is not None and
+                'currentListing' in res[0] and
                 res[0]['currentListing']['mediasetlisting$restartAllowed']):
             url = res[0]['currentListing']['restartUrl']
             return url.rpartition('/')[-1]


### PR DESCRIPTION
Make sure res and its first member are not NoneType before trying to iterate it.

Sometimes upstream URL downloads can return 403 errors like this:

```
2022-07-18 14:09:47.050 T:1312535424   DEBUG: plugin.video.videomediaset: Trying to get live and rewind channel program of id U0
2022-07-18 14:09:47.228 T:1312535424   DEBUG: plugin.video.videomediaset: Opening url https://static3.mediasetplay.mediaset.it/apigw/nownext/U0.json
2022-07-18 14:09:47.228 T:1312535424   DEBUG: plugin.video.videomediaset: Error opening url. Client error 403
2022-07-18 14:09:47.235 T:1312535424   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: argument of type 'NoneType' is not iterable
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/default.py", line 5, in <module>
                                                km.main()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 546, in main
                                                self.canali_live_root()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 370, in canali_live_root
                                                vid = self.__ottieni_vid_restart(prog['callSign'])
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 389, in __ottieni_vid_restart
                                                if ('currentListing' in res[0] and
                                            TypeError: argument of type 'NoneType' is not iterable
                                            -->End of Python script error report<--
2022-07-18 14:09:47.235 T:1312535424   DEBUG: onExecutionDone(10, /storage/.kodi/addons/plugin.video.videomediaset/default.py)
```

To avoid the error I simply skip empty res objects.

A better way could be to actually check if res is an Iterable, but doing that looks more convoluted in python, language in which I'm not fluent, so I'm going for the easy but incomplete solution.