### PR TITLE
Avoid errors when the mediasetlisting$restartAllowed value is missing.

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -353,7 +353,7 @@ class KodiMediaset(object):
                                                                      prog["mediasetlisting$epgTitle"])),
                                        'infos': _gather_info(prog),
                                        'arts': _gather_art(prog),
-                                       'restartAllowed': prog['mediasetlisting$restartAllowed']}
+                                       'restartAllowed': prog.get('mediasetlisting$restartAllowed', False)}
         els = self.med.OttieniCanaliLive(sort='ShortTitle')
         for prog in els:
             if (prog['callSign'] in chans and 'tuningInstruction' in prog and


### PR DESCRIPTION
I got this error today:

```python
2022-09-19 14:07:58.748 T:1798108032   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: 'mediasetlisting$restartAllowed'
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/default.py", line 5, in <module>
                                                km.main()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 542, in main
                                                self.canali_live_root()
                                              File "/storage/.kodi/addons/plugin.video.videomediaset/resources/main.py", line 352, in canali_live_root
                                                'restartAllowed': prog['mediasetlisting$restartAllowed']}
                                            KeyError: 'mediasetlisting$restartAllowed'
                                            -->End of Python script error report<--
```

Looks like the api allows the mediasetlisting$restartAllowed to be missing sometimes.

Fixed by using the dictionary .get() method.