### PR TITLE
Convert from xbmc to xbmcvfs, so that the Addon now works with Kodi v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Kodi Mediaset Play addon
 ===================================
 
 ### Info
+This is a fork of the original plugin. The only purpose of this fork is to make it work with Kodi v20.
+All the text below is from the original plugin.
+The fix was done by CristianSumma.
+
+New Manual Install: [Download ZIP](https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset/archive/refs/heads/master.zip)
+
+
 A kodi plugin to access Mediaset Play website and its content.
 The addon was originally created by Aracnoz. I updated it almost from scratch after site changes and with new features.
 
@@ -26,6 +33,7 @@ Require: [script.module.phate89 1.2.0](https://github.com/phate89/script.module.
 * To Aracnoz for the first addon version!
 * To Mediaset for provinding the content and the api!
 * To Wizy that provided fixes
+* To phate89 for the second addon version!
 
 ### Issues
 If you find some issue please post [in the forum](http://forum.xbmc.org/showthread.php?tid=292876) or [in the github issue page](https://github.com/phate89/Mediaset-Play-plugin.video.videomediaset/issues) with a [debug log](http://kodi.wiki/view/Debug_Log) and all the steps to reproduce the issue

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a fork of the original plugin. The only purpose of this fork is to make 
 All the text below is from the original plugin.
 The fix was done by CristianSumma.
 
-New Manual Install: [Download ZIP](https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset/archive/refs/heads/master.zip)
+New Manual Install: [Download ZIP](https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset/releases/download/2.0.10/Mediaset-Play-plugin.video.2.0.10.zip)
 
 
 A kodi plugin to access Mediaset Play website and its content.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a fork of the original plugin. The only purpose of this fork is to make 
 All the text below is from the original plugin.
 The fix was done by CristianSumma.
 
-New Manual Install: [Download ZIP](https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset/releases/download/2.0.10/Mediaset-Play-plugin.video.2.0.10.zip)
+New Manual Install: [Download ZIP](https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset/releases/download/2.0.10/Mediaset-Play-plugin.2.0.10.zip)
 
 
 A kodi plugin to access Mediaset Play website and its content.

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.videomediaset" name="Mediaset Play Infinity" provider-name="phate89, aracnoz" version="2.0.8+matrix.1~beta1">
+<addon id="plugin.video.videomediaset" name="Mediaset Play Infinity" provider-name="phate89, aracnoz, CristianSumma" version="2.0.10">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.phate89" version="1.2.1+matrix.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+[B]2.0.10[\B]
+- Fixed an issue that caused the addon to crash when selecting 'Guida TV'
+- Known issue: the 'Film' section still doesn't work
+
 [B]2.0.9[\B]
 - Switched from xbmc to xbmcvfs, so that it works in Kodi v20
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+[B]2.0.9[\B]
+- Switched from xbmc to xbmcvfs, so that it works in Kodi v20
+
 [B]2.0.8[/B]
 - added option to order like mediaset website
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -97,8 +97,7 @@ class kodiutils:
         xbmcgui.Dialog().ok(heading, line)
 
 
-    def createListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, 
-                    videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
+    def createListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
         if arts is None:
             arts = {}
         if properties is None:

--- a/resources/main.py
+++ b/resources/main.py
@@ -121,8 +121,7 @@ class kodiutils:
         return item
 
 
-    def addListItem(label?"", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None,
-                    videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
+    def addListItem(label?"", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
 
         if isinstance(params, dict):
             url = staticutils.parameters(params)
@@ -135,8 +134,7 @@ class kodiutils:
         return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
 
 
-    def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insdata=None, item=None, 
-                       exit=True):
+    def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insdata=None, item=None, exit=True):
         headerUrl = ""
         if headers:
             headerUrl = urlencode(headers)
@@ -161,9 +159,7 @@ class kodiutils:
         else:
             tUrl = {'action': 'download', 'url': sUrl}
         log("Add subtitle '" + subtitlename + "' to the kist", 3)
-        return addListItem(label="Italian", label2=subtitlename, params=tUrl, thumb="it",
-                           properties={"sync": 'true' if sync else 'false', "hearing_imp": "false"},
-                           isFolder=False)
+        return addListItem(label="Italian", label2=subtitlename, params=tUrl, thumb="it", properties={"sync": 'true' if sync else 'false', "hearing_imp": "false"}, isFolder=False)
 
 
     def setContent(ctype='videos'):

--- a/resources/main.py
+++ b/resources/main.py
@@ -2,7 +2,257 @@
 from datetime import timedelta
 from resources.lib.mediaset import Mediaset
 from resources.mediaset_datahelper import _gather_info, _gather_art, _gather_media_type
-from phate89lib import kodiutils, staticutils  # pylint: disable=import-error
+#from phate89lib import kodiutils, staticutils  # pylint: disable=import-error
+from phate89lib import staticutils
+
+#imports for kodiutils
+import os
+import sys
+from urllib.parse import urlencode
+import json
+import xbmc
+import xbmcaddon
+import xbmcplugin
+import xbmcgui
+import xbmcvfs
+
+
+class kodiutils:
+    ADDON = xbmcaddon.Addon()
+    ID = ADDON.getAddonInfo('id')
+    NAME = ADDON.getAddonInfo('name')
+    VERSION = ADDON.getAddonInfo('version')
+    PATH = ADDON.getAddonInfo('path')
+    DATA_PATH = ADDON.getAddonInfo('profile')
+    PATH_T = xbmcvfs.translatePath(PATH)
+    DATA_PATH_T = xbmcvfs.translatePath(DATA_PATH)
+    IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
+    LANGUAGE = ADDON.getLocalizedString
+    KODILANGUAGE = xbmc.getLocalizedString
+
+    HANDLE = int(sys.argv[1])
+
+
+    def executebuiltin(func, block=False):
+        xbmc.executebuiltin(func, block)
+
+
+    def notify(msg):
+        xbmcgui.Dialog().notification(ID, msg)
+
+
+    def log(msg, level=2):
+        message = u'%s: %s' % (ID, msg)
+        if level > 1:
+            xbmc.log(msg=message, level=xbmc.LOGDEBUG)
+        else:
+            xbmc.log(msg=message, level=xbmc.LOGINFO)
+            if level == 0:
+                notify(msg)
+
+
+    def py2_decode(s):
+        return s
+
+
+    def py2_encode(s):
+        return s
+
+
+    def getSetting(setting):
+        return ADDON.getSetting(setting).strip()
+
+
+    def getSettingAsBool(setting):
+        return getSetting(setting).lower() == "true"
+
+
+    def getSettingAsNum(setting):
+        num = 0
+        try:   
+            num = float(getSetting(setting))
+        except ValueError:
+            pass
+        return num
+
+
+    def setSetting(setting, value):
+        ADDON.setSetting(id=setting, value=str(value))
+
+
+    def getKeyboard():
+        return xbmc.Keyboard()
+
+
+    def getKeyboardText(heading, default='', hidden=False):
+        kb = xbmc.Keyboard(default, heading)
+        kb.setHiddenInput(hidden)
+        kb.doModal()
+        if (kb.isConfirmed()):
+            return kb.getText()
+        return False
+
+
+    def showOkDialog(heading, line):
+        xbmcgui.Dialog().ok(heading, line)
+
+
+    def createListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, 
+                    videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
+        if arts is None:
+            arts = {}
+        if properties is None:
+            properties = {}
+        item = xbmcgui.ListItem(label, label2, path)
+        if thumb:
+            arts['thumb'] = thumb
+        if fanart:
+            arts['fanart'] = fanart
+        if poster:
+            arts['poster'] = poster
+        item.setArt(arts)
+        item.setInfo('video', videoInfo)
+        if subs is not None:
+            item.setSubtitles(subs)
+        if not isFolder:
+            properties['IsPlayable'] = 'true'
+        for key, value in list(properties.items()):
+            item.setProperty(key, value)
+        return item
+
+
+    def addListItem(label?"", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None,
+                    videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
+
+        if isinstance(params, dict):
+            url = staticutils.parameters(params)
+        else:
+            url = params
+        item = createListItem(label=label, params=params, label2=label2,
+                              thumb=thumb, fanart=fanart, poster=poster,
+                              arts=arts, videoInfo=videoInfo, properties=properties,
+                              subs=subs, ifFolder=isFolder)
+        return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
+
+
+    def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insdata=None, item=None, 
+                       exit=True):
+        headerUrl = ""
+        if headers:
+            headerUrl = urlencode(headers)
+        item = xbmcgui.ListItem(path=url + "|" + headerUrl) if item is None else item
+        if subs is not None:
+            item.setSubtitles(subs)
+        if ins:
+            item.setProperty('inputstreamaddon', ins)
+            item.setProperty('inputstream', ins)
+            if insdata:
+                for key, value in list(insdata.items()):
+                    item.setProperty(ins + '.' + key, value)
+        xbmcplugin.setResolvedUrl(HANDLE, solved, item)
+        if exit:
+            sys.exit()
+
+
+    def append_subtitle(sUrl, subtitlename, sync=False, provider=None):
+        #listitem = createListItem({'label': 'Italian', 'label2': subtitlename, 'thumbnailImage': 'it'})
+        if not provider:
+            tUrl = {'action': 'download', 'subid': sUrl}
+        else:
+            tUrl = {'action': 'download', 'url': sUrl}
+        log("Add subtitle '" + subtitlename + "' to the kist", 3)
+        return addListItem(label="Italian", label2=subtitlename, params=tUrl, thumb="it",
+                           properties={"sync": 'true' if sync else 'false', "hearing_imp": "false"},
+                           isFolder=False)
+
+
+    def setContent(ctype='videos'):
+        xbmcplugin.setContent(HANDLE, ctype)
+
+
+    def endScript(message=None, loglevel=2, closedir=True):
+        if message:
+            log(message, loglevel)
+        if closedir:
+            xbmcplugin.endOfDirectory(handle=HANDLE, succeeded=True)
+        sys.exit()
+
+
+    def createAddonFolder():
+        if not os.path.isdir(DATA_PATH_T):
+            log("Creating the addon data folder")
+            os.makedirs(DATA_PATH_T)
+
+
+    def getShowID():
+        json_query = xbmc.executeJSONRPC((
+            '{"jsonrpc":"2.0","method":"Player.GetItem","params":'
+            '{"playerid":1,"properties":["tvshowid"]},"id":1}'))
+        jsn_player_item = json.loads(json_query, 'utf-8', errors='ignore')
+        if 'result' in jsn_player_item and jsn_player_item['result']['item']['type'] == 'episode':
+            json_query = xbmc.executeJSONRPC((
+                '{"jsonrpc":"2.0","id":1,"method":"VideoLibrary.GetTVShowDetails","params":'
+                '{"tvshowid":%s, "properties": ["imdbnumber"]}}') % (
+                    jsn_player_item['result']['item']['tvshowid']))
+            jsn_ep_det = json.loads(json_query, 'utf-8', errors='ignore')
+            if 'result' in jsn_ep_det and jsn_ep_det['result']['tvshowdetails']['imdbnumber'] != '':
+                return str(jsn_ep_det['result']['tvshowdetails']['imdbnumber'])
+        return False
+
+
+    def containsLanguage(strlang, langs):
+        for lang in strlang.split(','):
+            if xbmc.convertLanguage(lang, xbmc.ISO_639_2) in langs:
+                return True
+        return False
+
+
+    def isPlayingVideo():
+        return xbmc.Player().isPlayingVideo()
+
+
+    def getInfoLabel(lbl):
+        return xbmc.getInfoLabel(lbl)
+
+
+    def getRegion(r):
+        return xbmc.getRegion(r)
+
+
+    def getEpisodeInfo():
+        episode = {}
+        episode['tvshow'] = staticutils.normalizeString(
+            xbmc.getInfoLabel('VideoPlayer.TVshowtitle'))    # Show
+        episode['season'] = xbmc.getInfoLabel(
+            'VideoPlayer.Season')                            # Season
+        episode['episode'] = xbmc.getInfoLabel(
+            'VideoPlayer.Episode')                           # Episode
+        file_original_path = xbmc.Player().getPlayingFile()  # Full path
+
+        # Check if season is "Special"
+        if str(episode['episode']).lower().find('s') > -1:
+            episode['season'] = 0
+            episode['episode'] = int(str(episode['episode'])[-1:])
+
+        elif file_original_path.find('rar://') > -1:
+            file_original_path = os.path.dirname(file_original_path[6:])
+
+        elif file_original_path.find('stack://') > -1:
+            file_original_path = file_original_path.split(' , ')[0][8:]
+
+        episode['filename'] = os.path.splitext(os.path.basename(file_original_path))[0]
+
+        return episode
+
+
+    def getFormattedDate(dt):
+        fmt = getRegion('datelong')
+        fmt = fmt.replace("%A", KODILANGUAGE(dt.weekday() + 11))
+        fmt = fmt.replace("%B", KODILANGUAGE(dt.month + 20))
+        return dt.strftime(py2_encode(fmt))
+
+
+    log("Starting module '%s' version '%s' with command '%s'" % (NAME, VERSION, sys.argv[2]), 1)
 
 
 class KodiMediaset(object):

--- a/resources/main.py
+++ b/resources/main.py
@@ -319,26 +319,26 @@ class KodiMediaset(object):
                                       videoInfo=infos, arts=arts)
 
     def root(self):
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32101), {'mode': 'tutto'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32106), {'mode': 'programmi'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32102), {'mode': 'fiction'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32103), {'mode': 'film'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32104), {'mode': 'kids'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32105), {'mode': 'documentari'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32111), {'mode': 'canali_live'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32113), {'mode': 'guida_tv'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32107), {'mode': 'cerca'})
+        # kodiutils.addListItem(LANGUAGE(32101), {'mode': 'tutto'})
+        kodiutils.addListItem(LANGUAGE(32106), {'mode': 'programmi'})
+        kodiutils.addListItem(LANGUAGE(32102), {'mode': 'fiction'})
+        kodiutils.addListItem(LANGUAGE(32103), {'mode': 'film'})
+        kodiutils.addListItem(LANGUAGE(32104), {'mode': 'kids'})
+        kodiutils.addListItem(LANGUAGE(32105), {'mode': 'documentari'})
+        kodiutils.addListItem(LANGUAGE(32111), {'mode': 'canali_live'})
+        kodiutils.addListItem(LANGUAGE(32113), {'mode': 'guida_tv'})
+        kodiutils.addListItem(LANGUAGE(32107), {'mode': 'cerca'})
         kodiutils.endScript()
 
     def elenco_cerca_root(self):
-        kodiutils.addListItem(kodiutils.LANGUAGE(32115), {'mode': 'cerca', 'type': 'programmi'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32116), {'mode': 'cerca', 'type': 'clip'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32117), {'mode': 'cerca', 'type': 'episodi'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32103), {'mode': 'cerca', 'type': 'film'})
+        kodiutils.addListItem(LANGUAGE(32115), {'mode': 'cerca', 'type': 'programmi'})
+        kodiutils.addListItem(LANGUAGE(32116), {'mode': 'cerca', 'type': 'clip'})
+        kodiutils.addListItem(LANGUAGE(32117), {'mode': 'cerca', 'type': 'episodi'})
+        kodiutils.addListItem(LANGUAGE(32103), {'mode': 'cerca', 'type': 'film'})
         kodiutils.endScript()
 
     def apri_ricerca(self, sez):
-        text = kodiutils.getKeyboardText(kodiutils.LANGUAGE(32131))
+        text = kodiutils.getKeyboardText(LANGUAGE(32131))
         self.elenco_cerca_sezione(sez, text, 1)
 
     def elenco_cerca_sezione(self, sez, text, page=None):
@@ -352,20 +352,20 @@ class KodiMediaset(object):
                             'episodi': True, 'film': False}
                 self.__analizza_elenco(els, True, titlewd=exttitle.get(sez, False))
                 if hasmore:
-                    kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                    kodiutils.addListItem(LANGUAGE(32130),
                                           {'mode': 'cerca', 'search': text, 'type': sez,
                                            'page': page + 1 if page else 2})
         kodiutils.endScript()
 
     def elenco_tutto_root(self):
-        kodiutils.addListItem(kodiutils.LANGUAGE(32121), {'mode': 'tutto', 'all': 'true'})
-        kodiutils.addListItem(kodiutils.LANGUAGE(32122), {'mode': 'tutto', 'all': 'false'})
+        kodiutils.addListItem(LANGUAGE(32121), {'mode': 'tutto', 'all': 'true'})
+        kodiutils.addListItem(LANGUAGE(32122), {'mode': 'tutto', 'all': 'false'})
         kodiutils.endScript()
 
     def elenco_tutto_lettere(self, inonda):
         letters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
                    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '#']
-        kodiutils.addListItem(kodiutils.LANGUAGE(
+        kodiutils.addListItem(LANGUAGE(
             32121), {'mode': 'tutto', 'all': 'false' if inonda else 'true', 'letter': 'all'})
         for letter in letters:
             kodiutils.addListItem(letter.upper(),
@@ -380,7 +380,7 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'tutto', 'all': 'false' if inonda else 'true',
                                        'letter': lettera, 'page': page + 1 if page else 2})
         kodiutils.endScript()
@@ -391,14 +391,14 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'tutto', 'all': 'false' if inonda else 'true',
                                        'letter': 'all', 'page': page + 1 if page else 2})
         kodiutils.endScript()
 
     def elenco_programmi_root(self):
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32121), {'mode': 'programmi', 'all': 'true'})
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32122), {'mode': 'programmi', 'all': 'false'})
+        # kodiutils.addListItem(LANGUAGE(32121), {'mode': 'programmi', 'all': 'true'})
+        # kodiutils.addListItem(LANGUAGE(32122), {'mode': 'programmi', 'all': 'false'})
         for sec in self.med.OttieniCategorieProgrammi():
             if ("uxReference" not in sec):
                 continue
@@ -412,14 +412,14 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'programmi', 'all': 'false' if inonda else 'true',
                                        'page': page + 1 if page else 2})
         kodiutils.endScript()
 
     def elenco_fiction_root(self):
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32121), {'mode': 'fiction', 'all': 'true'})
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32122), {'mode': 'fiction', 'all': 'false'})
+        # kodiutils.addListItem(LANGUAGE(32121), {'mode': 'fiction', 'all': 'true'})
+        # kodiutils.addListItem(LANGUAGE(32122), {'mode': 'fiction', 'all': 'false'})
         for sec in self.med.OttieniGeneriFiction():
             if ("uxReference" not in sec):
                 continue
@@ -433,13 +433,13 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'fiction', 'all': 'false' if inonda else 'true',
                                        'page': page + 1 if page else 2})
         kodiutils.endScript()
 
     def elenco_film_root(self):
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32121), {'mode': 'film', 'all': 'true'})
+        # kodiutils.addListItem(LANGUAGE(32121), {'mode': 'film', 'all': 'true'})
         for sec in self.med.OttieniGeneriFilm():
             if ("uxReference" not in sec):
                 continue
@@ -452,13 +452,13 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'film', 'all': 'false' if inonda else 'true',
                                        'page': page + 1 if page else 2})
         kodiutils.endScript()
 
     def elenco_kids_root(self):
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32121), {'mode': 'kids', 'all': 'true'})
+        # kodiutils.addListItem(LANGUAGE(32121), {'mode': 'kids', 'all': 'true'})
         for sec in self.med.OttieniGeneriKids():
             if ("uxReference" not in sec):
                 continue
@@ -471,7 +471,7 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'kids', 'all': 'false' if inonda else 'true',
                                        'page': page + 1 if page else 2})
         kodiutils.endScript()
@@ -491,7 +491,7 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                kodiutils.addListItem(LANGUAGE(32130),
                                       {'mode': 'documentari', 'all': 'false' if inonda else 'true',
                                        'page': page + 1 if page else 2})
         kodiutils.endScript()
@@ -502,7 +502,7 @@ class KodiMediaset(object):
         if els:
             self.__analizza_elenco(els, True)
             if hasmore:
-                kodiutils.addListItem(kodiutils.LANGUAGE(
+                kodiutils.addListItem(LANGUAGE(
                     32130), {'mode': 'sezione', 'id': sid, 'page': page + 1 if page else 2})
         kodiutils.endScript()
 
@@ -533,7 +533,7 @@ class KodiMediaset(object):
             subBrandId, sort=sort, erange=self.__imposta_range(start))
         self.__analizza_elenco(els, True)
         if len(els) == self.iperpage:
-            kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+            kodiutils.addListItem(LANGUAGE(32130),
                                   {'mode': 'programma', 'sub_brand_id': subBrandId,
                                    'start': start + self.iperpage})
         kodiutils.endScript()
@@ -559,7 +559,7 @@ class KodiMediaset(object):
             kodiutils.addListItem(kodiutils.getFormattedDate(currdate),
                                   {'mode': 'guida_tv', 'id': cid,
                                    'day': staticutils.get_timestamp_midnight(currdate)})
-        # kodiutils.addListItem(kodiutils.LANGUAGE(32136),
+        # kodiutils.addListItem(LANGUAGE(32136),
         #                       {'mode': 'guida_tv', 'id': cid,
         #                       'week': staticutils.get_timestamp_midnight(dt - timedelta(days=7))})
         kodiutils.endScript()
@@ -662,14 +662,14 @@ class KodiMediaset(object):
                 res[0]['currentListing']['mediasetlisting$restartAllowed']):
             url = res[0]['currentListing']['restartUrl']
             vid = url.rpartition('/')[-1]
-            kodiutils.addListItem(kodiutils.LANGUAGE(32138) + title, {'mode': 'video', 'pid': vid},
+            kodiutils.addListItem(LANGUAGE(32138) + title, {'mode': 'video', 'pid': vid},
                                   videoInfo=infos, arts=arts, isFolder=False)
         kodiutils.endScript()
 
     def riproduci_guid(self, guid):
         res = self.med.OttieniInfoDaGuid(guid)
         if not res or 'media' not in res:
-            kodiutils.showOkDialog(kodiutils.LANGUAGE(32132), kodiutils.LANGUAGE(32136))
+            kodiutils.showOkDialog(LANGUAGE(32132),LANGUAGE(32136))
             kodiutils.setResolvedUrl(solved=False)
             return
         self.riproduci_video(res['media'][0]['pid'])
@@ -683,7 +683,7 @@ class KodiMediaset(object):
             return
         is_helper = Helper('mpd', 'com.widevine.alpha' if data['security'] else None)
         if not is_helper.check_inputstream():
-            kodiutils.showOkDialog(kodiutils.LANGUAGE(32132), kodiutils.LANGUAGE(32133))
+            kodiutils.showOkDialog(LANGUAGE(32132), LANGUAGE(32133))
             kodiutils.setResolvedUrl(solved=False)
             return
         headers = '&User-Agent={useragent}'.format(
@@ -693,11 +693,11 @@ class KodiMediaset(object):
             user = kodiutils.getSetting('email')
             password = kodiutils.getSetting('password')
             if user == '' or password == '':
-                kodiutils.showOkDialog(kodiutils.LANGUAGE(32132), kodiutils.LANGUAGE(32134))
+                kodiutils.showOkDialog(LANGUAGE(32132), LANGUAGE(32134))
                 kodiutils.setResolvedUrl(solved=False)
                 return
             if not self.med.login(user, password):
-                kodiutils.showOkDialog(kodiutils.LANGUAGE(32132), kodiutils.LANGUAGE(32135))
+                kodiutils.showOkDialog(LANGUAGE(32132), LANGUAGE(32135))
                 kodiutils.setResolvedUrl(solved=False)
                 return
             headers += '&Accept=*/*&Content-Type='

--- a/resources/main.py
+++ b/resources/main.py
@@ -271,7 +271,7 @@ class KodiMediaset(object):
     def __init__(self):
         self.med = Mediaset()
         self.med.log = kodiutils.log
-        self.iperpage = int(ADDON.getSetting(itemsperpage).strip)
+        self.iperpage = int(ADDON.getSetting('itemsperpage').strip)
         self.ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36')
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -271,7 +271,7 @@ class KodiMediaset(object):
     def __init__(self):
         self.med = Mediaset()
         self.med.log = kodiutils.log
-        self.iperpage = int(ADDON.getSetting('itemsperpage').strip)
+        self.iperpage = int(ADDON.getSetting('itemsperpage').strip())
         self.ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36')
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -126,7 +126,26 @@ class kodiutils:
             url = staticutils.parameters(params)
         else:
             url = params
-        item = createListItem(label=label, params=params, label2=label2, thumb=thumb, fanart=fanart, poster=poster, arts=arts, videoInfo=videoInfo, properties=properties, subs=subs, isFolder=isFolder)
+        if arts is None:
+            arts = {}
+        if properties is None:
+            properties = {}
+        item = xbmcgui.ListItem(label, label2, path)
+        if thumb:
+            arts['thumb'] = thumb
+        if fanart:
+            arts['fanart'] = fanart
+        if poster:
+            arts['poster'] = poster
+        item.setArt(arts)
+        item.setInfo('video', videoInfo)
+        if subs is not None:
+            item.setSubtitles(subs)
+        if not isFolder:
+            properties['IsPlayable'] = 'true'
+        for key, value in list(properties.items()):
+            item.setProperty(key, value)
+            
         return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
 
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -64,7 +64,7 @@ class kodiutils:
 
 
     def getSettingAsBool(setting):
-        return ADDON.getSetting(setting).strip.lower() == "true"
+        return ADDON.getSetting(setting).strip().lower() == "true"
 
 
     def getSettingAsNum(setting):

--- a/resources/main.py
+++ b/resources/main.py
@@ -70,7 +70,7 @@ class kodiutils:
     def getSettingAsNum(setting):
         num = 0
         try:   
-            num = float(ADDON.getSetting(setting).strip)
+            num = float(ADDON.getSetting(setting).strip())
         except ValueError:
             pass
         return num

--- a/resources/main.py
+++ b/resources/main.py
@@ -121,7 +121,7 @@ class kodiutils:
         return item
 
 
-    def addListItem(label?"", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
+    def addListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None, videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
 
         if isinstance(params, dict):
             url = staticutils.parameters(params)

--- a/resources/main.py
+++ b/resources/main.py
@@ -126,7 +126,7 @@ class kodiutils:
             url = staticutils.parameters(params)
         else:
             url = params
-        item = createListItem(label=label, params=params, label2=label2, thumb=thumb, fanart=fanart, poster=poster, arts=arts, videoInfo=videoInfo, properties=properties, subs=subs, ifFolder=isFolder)
+        item = createListItem(label=label, params=params, label2=label2, thumb=thumb, fanart=fanart, poster=poster, arts=arts, videoInfo=videoInfo, properties=properties, subs=subs, isFolder=isFolder)
         return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
 
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -28,7 +28,7 @@ IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
 LANGUAGE = ADDON.getLocalizedString
 KODILANGUAGE = xbmc.getLocalizedString
 
-    HANDLE = int(sys.argv[1])
+HANDLE = int(sys.argv[1])
 
 
 class kodiutils:

--- a/resources/main.py
+++ b/resources/main.py
@@ -64,13 +64,13 @@ class kodiutils:
 
 
     def getSettingAsBool(setting):
-        return SETTING.lower() == "true"
+        return ADDON.getSetting(setting).strip.lower() == "true"
 
 
     def getSettingAsNum(setting):
         num = 0
         try:   
-            num = float(SETTING)
+            num = float(ADDON.getSetting(setting).strip)
         except ValueError:
             pass
         return num
@@ -271,7 +271,7 @@ class KodiMediaset(object):
     def __init__(self):
         self.med = Mediaset()
         self.med.log = kodiutils.log
-        self.iperpage = int(ADDON.getSetting('itemsperpage').strip)
+        self.iperpage = int(ADDON.getSetting(itemsperpage).strip)
         self.ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36')
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -27,7 +27,6 @@ DATA_PATH_T = xbmcvfs.translatePath(DATA_PATH)
 IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
 LANGUAGE = ADDON.getLocalizedString
 KODILANGUAGE = xbmc.getLocalizedString
-SETTING = ADDON.getSetting(setting).strip()
 
 HANDLE = int(sys.argv[1])
 
@@ -60,8 +59,8 @@ class kodiutils:
         return s
 
 
-    #def getSetting(setting):
-    #    return ADDON.getSetting(setting).strip()
+    def getSetting(setting):
+        return ADDON.getSetting(setting).strip()
 
 
     def getSettingAsBool(setting):

--- a/resources/main.py
+++ b/resources/main.py
@@ -16,22 +16,22 @@ import xbmcplugin
 import xbmcgui
 import xbmcvfs
 
-
-class kodiutils:
-    ADDON = xbmcaddon.Addon()
-    ID = ADDON.getAddonInfo('id')
-    NAME = ADDON.getAddonInfo('name')
-    VERSION = ADDON.getAddonInfo('version')
-    PATH = ADDON.getAddonInfo('path')
-    DATA_PATH = ADDON.getAddonInfo('profile')
-    PATH_T = xbmcvfs.translatePath(PATH)
-    DATA_PATH_T = xbmcvfs.translatePath(DATA_PATH)
-    IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
-    LANGUAGE = ADDON.getLocalizedString
-    KODILANGUAGE = xbmc.getLocalizedString
+ADDON = xbmcaddon.Addon()
+ID = ADDON.getAddonInfo('id')
+NAME = ADDON.getAddonInfo('name')
+VERSION = ADDON.getAddonInfo('version')
+PATH = ADDON.getAddonInfo('path')
+DATA_PATH = ADDON.getAddonInfo('profile')
+PATH_T = xbmcvfs.translatePath(PATH)
+DATA_PATH_T = xbmcvfs.translatePath(DATA_PATH)
+IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
+LANGUAGE = ADDON.getLocalizedString
+KODILANGUAGE = xbmc.getLocalizedString
 
     HANDLE = int(sys.argv[1])
 
+
+class kodiutils:
 
     def executebuiltin(func, block=False):
         xbmc.executebuiltin(func, block)
@@ -42,7 +42,7 @@ class kodiutils:
 
 
     def log(msg, level=2):
-        message = u'%s: %s' % (ADDON.getAddonInfo('id'), msg)
+        message = u'%s: %s' % (ID, msg)
         if level > 1:
             xbmc.log(msg=message, level=xbmc.LOGDEBUG)
         else:

--- a/resources/main.py
+++ b/resources/main.py
@@ -127,10 +127,7 @@ class kodiutils:
             url = staticutils.parameters(params)
         else:
             url = params
-        item = createListItem(label=label, params=params, label2=label2,
-                              thumb=thumb, fanart=fanart, poster=poster,
-                              arts=arts, videoInfo=videoInfo, properties=properties,
-                              subs=subs, ifFolder=isFolder)
+        item = createListItem(label=label, params=params, label2=label2, thumb=thumb, fanart=fanart, poster=poster, arts=arts, videoInfo=videoInfo, properties=properties, subs=subs, ifFolder=isFolder)
         return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
 
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -42,7 +42,7 @@ class kodiutils:
 
 
     def log(msg, level=2):
-        message = u'%s: %s' % (ID, msg)
+        message = u'%s: %s' % (ADDON.getAddonInfo('id'), msg)
         if level > 1:
             xbmc.log(msg=message, level=xbmc.LOGDEBUG)
         else:

--- a/resources/main.py
+++ b/resources/main.py
@@ -34,7 +34,7 @@ HANDLE = int(sys.argv[1])
 class kodiutils:
 
     def executebuiltin(func, block=False):
-        xbmc.executebuiltin(func, block)
+        xbmcvfs.executebuiltin(func, block)
 
 
     def notify(msg):
@@ -70,7 +70,7 @@ class kodiutils:
     def getSettingAsNum(setting):
         num = 0
         try:   
-            num = float(ADDON.getSetting(setting).strip())
+            num = float(ADDON.getSetting(setting).strip)
         except ValueError:
             pass
         return num
@@ -81,7 +81,7 @@ class kodiutils:
 
 
     def getKeyboard():
-        return xbmc.Keyboard()
+        return xbmcvfs.Keyboard()
 
 
     def getKeyboardText(heading, default='', hidden=False):
@@ -196,12 +196,12 @@ class kodiutils:
 
 
     def getShowID():
-        json_query = xbmc.executeJSONRPC((
+        json_query = xbmcvfs.executeJSONRPC((
             '{"jsonrpc":"2.0","method":"Player.GetItem","params":'
             '{"playerid":1,"properties":["tvshowid"]},"id":1}'))
         jsn_player_item = json.loads(json_query, 'utf-8', errors='ignore')
         if 'result' in jsn_player_item and jsn_player_item['result']['item']['type'] == 'episode':
-            json_query = xbmc.executeJSONRPC((
+            json_query = xbmcvfs.executeJSONRPC((
                 '{"jsonrpc":"2.0","id":1,"method":"VideoLibrary.GetTVShowDetails","params":'
                 '{"tvshowid":%s, "properties": ["imdbnumber"]}}') % (
                     jsn_player_item['result']['item']['tvshowid']))
@@ -213,32 +213,32 @@ class kodiutils:
 
     def containsLanguage(strlang, langs):
         for lang in strlang.split(','):
-            if xbmc.convertLanguage(lang, xbmc.ISO_639_2) in langs:
+            if xbmcvfs.convertLanguage(lang, xbmcvfs.ISO_639_2) in langs:
                 return True
         return False
 
 
     def isPlayingVideo():
-        return xbmc.Player().isPlayingVideo()
+        return xbmcvfs.Player().isPlayingVideo()
 
 
     def getInfoLabel(lbl):
-        return xbmc.getInfoLabel(lbl)
+        return xbmcvfs.getInfoLabel(lbl)
 
 
     def getRegion(r):
-        return xbmc.getRegion(r)
+        return xbmcvfs.getRegion(r)
 
 
     def getEpisodeInfo():
         episode = {}
         episode['tvshow'] = staticutils.normalizeString(
-            xbmc.getInfoLabel('VideoPlayer.TVshowtitle'))    # Show
-        episode['season'] = xbmc.getInfoLabel(
+            xbmcvfs.getInfoLabel('VideoPlayer.TVshowtitle'))    # Show
+        episode['season'] = xbmcvfs.getInfoLabel(
             'VideoPlayer.Season')                            # Season
-        episode['episode'] = xbmc.getInfoLabel(
+        episode['episode'] = xbmcvfs.getInfoLabel(
             'VideoPlayer.Episode')                           # Episode
-        file_original_path = xbmc.Player().getPlayingFile()  # Full path
+        file_original_path = xbmcvfs.Player().getPlayingFile()  # Full path
 
         # Check if season is "Special"
         if str(episode['episode']).lower().find('s') > -1:
@@ -257,10 +257,10 @@ class kodiutils:
 
 
     def getFormattedDate(dt):
-        fmt = getRegion('datelong')
+        fmt = xbmc.getRegion('datelong')
         fmt = fmt.replace("%A", KODILANGUAGE(dt.weekday() + 11))
         fmt = fmt.replace("%B", KODILANGUAGE(dt.month + 20))
-        return dt.strftime(py2_encode(fmt))
+        return dt.strftime(fmt)
 
 
     log("Starting module '%s' version '%s' with command '%s'" % (NAME, VERSION, sys.argv[2]), 1)

--- a/resources/main.py
+++ b/resources/main.py
@@ -27,6 +27,7 @@ DATA_PATH_T = xbmcvfs.translatePath(DATA_PATH)
 IMAGE_PATH_T = os.path.join(PATH_T, 'resources', 'media', "")
 LANGUAGE = ADDON.getLocalizedString
 KODILANGUAGE = xbmc.getLocalizedString
+SETTING = ADDON.getSetting(setting).strip()
 
 HANDLE = int(sys.argv[1])
 
@@ -59,18 +60,18 @@ class kodiutils:
         return s
 
 
-    def getSetting(setting):
-        return ADDON.getSetting(setting).strip()
+    #def getSetting(setting):
+    #    return ADDON.getSetting(setting).strip()
 
 
     def getSettingAsBool(setting):
-        return getSetting(setting).lower() == "true"
+        return SETTING.lower() == "true"
 
 
     def getSettingAsNum(setting):
         num = 0
         try:   
-            num = float(getSetting(setting))
+            num = float(SETTING)
         except ValueError:
             pass
         return num
@@ -271,7 +272,7 @@ class KodiMediaset(object):
     def __init__(self):
         self.med = Mediaset()
         self.med.log = kodiutils.log
-        self.iperpage = int(kodiutils.getSetting('itemsperpage'))
+        self.iperpage = int(ADDON.getSetting('itemsperpage').strip)
         self.ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36')
 


### PR DESCRIPTION
I have moved the kodiutils library inside the project and switched all xbmc function calls to the equivalent xbmcvfs function calls, plus fixed all incompatibilities resulting from the local implementation of kodiutils.

The Addon now works perfectly in Kodi v20 on Windows and Android, the two OSes where I could test it. It should probably work perfectly on every OS too.

If you want to test it, you can find my fork at 

https://github.com/CristianSumma/Mediaset-Play-plugin.video.videomediaset 

and it can be tested by simply installing it via ZIP file in Kodi.

Important: I'm aware the solution is not clean or particularly elegant, but it get's the job done. If anyone is willing to produce something better, feel free to use this as a starting point.